### PR TITLE
Enhance error logging in `DisableLinksForUser` by integrating `logrus…

### DIFF
--- a/server/pkg/repo/public/file_link.go
+++ b/server/pkg/repo/public/file_link.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	"github.com/ente-io/museum/ente/base"
 	"github.com/lib/pq"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 
 	"github.com/ente-io/museum/ente"
@@ -128,7 +130,7 @@ func (pcr *FileLinkRepository) DisableLinkForFiles(ctx context.Context, fileIDs 
 func (pcr *FileLinkRepository) DisableLinksForUser(ctx context.Context, userID int64) error {
 	_, err := pcr.DB.ExecContext(ctx, `UPDATE public_file_tokens SET is_disabled = TRUE WHERE owner_id = $1`, userID)
 	if err != nil {
-		return stacktrace.Propagate(err, "failed to disable public file link")
+		log.Warn("failed to disable public file link")
 	}
 	return nil
 }


### PR DESCRIPTION
…` and replacing `stacktrace.Propagate` with `log.Warn`.

## Description

## Tests
