### PR TITLE
UNP-6125: Update CODEOWNERS for server and mobile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 /server/ @up-andrey
 
 # Mobile code
-/mobile/ @up-nadav
+/mobile/ @nadav-unplugged

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,8 @@
 # This file defines who owns the code and will be automatically requested for review on pull requests
 # More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Default owner for all files in the repository
-* @up-andrey
+# Server code
+/server/ @up-andrey
+
+# Mobile code
+/mobile/ @up-nadav


### PR DESCRIPTION
## Summary
- Assigned @up-andrey as code owner for `/server/`
- Assigned @up-nadav as code owner for `/mobile/`
- Removed single default owner for the entire repo

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm correct reviewers are auto-requested on PRs touching server/ and mobile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)