### PR TITLE
UNP-7662 use AES-GCM and RSA-OAEP for Android secure storage

### DIFF
--- a/mobile/apps/photos/lib/core/configuration.dart
+++ b/mobile/apps/photos/lib/core/configuration.dart
@@ -94,6 +94,7 @@ class Configuration {
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock_this_device,
         ),
+        aOptions: kSecureStorageAndroidOptions,
       );
       _documentsDirectory = (await getApplicationDocumentsDirectory()).path;
       _tempDocumentsDirPath = _documentsDirectory + "/temp/";
@@ -143,9 +144,14 @@ class Configuration {
        */
       if (e is PlatformException) {
         final PlatformException error = e;
+        // AES-GCM reports a failed integrity check as AEADBadTagException,
+        // whose name does not contain "BadPaddingException", so match it too.
+        bool indicatesUndecryptableValue(String s) =>
+            s.contains('BadPaddingException') ||
+            s.contains('AEADBadTagException');
         final bool isBadPaddingError =
-            error.toString().contains('BadPaddingException') ||
-                (error.message ?? '').contains('BadPaddingException');
+            indicatesUndecryptableValue(error.toString()) ||
+                indicatesUndecryptableValue(error.message ?? '');
         if (isBadPaddingError) {
           await logout(autoLogout: true);
           return;

--- a/mobile/apps/photos/lib/core/constants.dart
+++ b/mobile/apps/photos/lib/core/constants.dart
@@ -1,4 +1,5 @@
 import "package:flutter/foundation.dart";
+import "package:flutter_secure_storage/flutter_secure_storage.dart";
 
 const int thumbnailSmallSize = 256;
 const int thumbnailQuality = 50;
@@ -109,3 +110,22 @@ const kFilterChipHeight = 32.0;
 const kMaxAppbarFilters = 14;
 
 const kLivePhotoHashSeparator = ':';
+
+// Ciphers used by flutter_secure_storage on Android, overriding package
+// defaults that are both vulnerable to padding oracle attacks:
+//
+//  - values: AES-GCM instead of AES-CBC/PKCS7, which has no integrity check.
+//  - AES key wrapping: RSA-OAEP instead of RSA/ECB/PKCS1, which is open to
+//    Bleichenbacher's attack.
+//
+// Both require API 23+, and minSdk is 26. Switching either one makes the plugin
+// re-encrypt existing values on next launch, so upgrading users keep their data.
+//
+// Every FlutterSecureStorage instance in the app must be constructed with these
+// options. Instances share a single preferences file, so any instance left on
+// the defaults would re-encrypt that file back to AES-CBC on each launch,
+// fighting the instances that use AES-GCM.
+const kSecureStorageAndroidOptions = AndroidOptions(
+  storageCipherAlgorithm: StorageCipherAlgorithm.AES_GCM_NoPadding,
+  keyCipherAlgorithm: KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding,
+);

--- a/mobile/apps/photos/lib/utils/lock_screen_settings.dart
+++ b/mobile/apps/photos/lib/utils/lock_screen_settings.dart
@@ -5,6 +5,7 @@ import "package:flutter/foundation.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:flutter_sodium/flutter_sodium.dart";
 import "package:logging/logging.dart";
+import "package:photos/core/constants.dart";
 import "package:privacy_screen/privacy_screen.dart";
 import "package:shared_preferences/shared_preferences.dart";
 
@@ -31,7 +32,9 @@ class LockScreenSettings {
     Duration(minutes: 30),
   ];
   Future<void> init(SharedPreferences prefs) async {
-    _secureStorage = const FlutterSecureStorage();
+    _secureStorage = const FlutterSecureStorage(
+      aOptions: kSecureStorageAndroidOptions,
+    );
     _preferences = prefs;
 
     await Future.delayed(const Duration(milliseconds: 500), () {

--- a/mobile/apps/photos/pubspec.yaml
+++ b/mobile/apps/photos/pubspec.yaml
@@ -12,7 +12,7 @@ description: ente photos application
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.2.157+1224
+version: 1.2.158+1225
 publish_to: none
 
 environment:


### PR DESCRIPTION
flutter_secure_storage defaults to AES-CBC/PKCS7 for values and RSA/ECB/PKCS1 for key wrapping, both open to padding oracle attacks. Options are shared via one const so instances cannot disagree and re-encrypt the same preferences file against each other.

## Description

## Tests
